### PR TITLE
Очистка суммы доставки сдэк при смене опции

### DIFF
--- a/assets/js/cdek-delivery-classic.js
+++ b/assets/js/cdek-delivery-classic.js
@@ -385,11 +385,11 @@ jQuery(document).ready(function($) {
             var maxBoxVolume = standardBoxes[standardBoxes.length - 1].volume; // Самая большая коробка
             packagesCount = Math.ceil(packingVolume / maxBoxVolume);
             
-            // Ограничиваем максимальное количество коробок для разумности
-            if (packagesCount > 10) {
-                packagesCount = 10;
-                console.log('⚠️ Ограничиваем количество коробок до 10');
-            }
+                    // Ограничиваем максимальное количество коробок для API СДЭК
+        if (packagesCount > 5) {
+            packagesCount = 5;
+            console.log('⚠️ Ограничиваем количество коробок до 5 (ограничение API СДЭК)');
+        }
             
             // Объем на одну коробку
             var volumePerBox = packingVolume / packagesCount;
@@ -508,7 +508,29 @@ jQuery(document).ready(function($) {
                 if (response && response.success && response.data && response.data.delivery_sum) {
                     var deliveryCost = parseInt(response.data.delivery_sum);
                     
-                    if (cartData.packagesCount > 1) {
+                    // Проверяем, использовался ли fallback расчет
+                    if (response.data.fallback_used) {
+                        console.log('⚠️ Используется приблизительный расчет для большого заказа: ' + deliveryCost + ' руб.');
+                        
+                        // Показываем пользователю предупреждение
+                        if (cartData.packagesCount >= 5) {
+                            setTimeout(function() {
+                                var warningHtml = '<div class="cdek-fallback-warning" style="background: #fff3cd; border: 1px solid #ffeaa7; color: #856404; padding: 10px; margin: 10px 0; border-radius: 4px; font-size: 14px;">' +
+                                    '<strong>ℹ️ Приблизительная стоимость</strong><br>' +
+                                    'Для большого заказа (' + cartData.packagesCount + ' коробок) показана приблизительная стоимость доставки. ' +
+                                    'Точная стоимость будет уточнена при обработке заказа.' +
+                                    '</div>';
+                                
+                                $('.cdek-fallback-warning').remove(); // Удаляем предыдущие предупреждения
+                                $('#cdek-delivery-content').prepend(warningHtml);
+                            }, 500);
+                        }
+                    } else {
+                        // Убираем предупреждение если расчет точный
+                        $('.cdek-fallback-warning').remove();
+                    }
+                    
+                    if (cartData.packagesCount > 1 && !response.data.fallback_used) {
                         deliveryCost = deliveryCost * cartData.packagesCount;
                     }
                     

--- a/assets/js/cdek-delivery-classic.js
+++ b/assets/js/cdek-delivery-classic.js
@@ -236,6 +236,23 @@ jQuery(document).ready(function($) {
     
     // ========== ФУНКЦИИ ДЛЯ РАСЧЕТА ГАБАРИТОВ И СТОИМОСТИ ==========
     
+    // Вспомогательная функция для корректного парсинга цен
+    function parsePrice(priceText) {
+        if (!priceText) return 0;
+        
+        // Удаляем все символы кроме цифр и точек/запятых
+        var cleanText = priceText.toString().replace(/[^\d.,]/g, '');
+        
+        // Заменяем запятые на точки для decimal
+        cleanText = cleanText.replace(',', '.');
+        
+        // Парсим как float и округляем до целых
+        var result = Math.round(parseFloat(cleanText)) || 0;
+        
+        console.log('💰 Парсинг цены:', priceText, '→', cleanText, '→', result);
+        return result;
+    }
+    
     function getCartDataForCalculation() {
         var cartWeight = 0;
         var cartValue = 0;
@@ -308,8 +325,8 @@ jQuery(document).ready(function($) {
         // Получаем общую стоимость заказа из элементов страницы
         var orderTotalElement = $('.cart-subtotal .amount');
         if (orderTotalElement.length > 0) {
-            var totalText = orderTotalElement.first().text().replace(/[^\d]/g, '');
-            var parsedValue = parseInt(totalText);
+            var totalText = orderTotalElement.first().text();
+            var parsedValue = parsePrice(totalText);
             if (parsedValue > 0) {
                 cartValue = parsedValue;
             }
@@ -1475,8 +1492,8 @@ jQuery(document).ready(function($) {
         var subtotal = 0;
         
         if (subtotalElement.length > 0) {
-            var subtotalText = subtotalElement.first().text().replace(/[^\d]/g, '');
-            subtotal = parseInt(subtotalText) || 0;
+            var subtotalText = subtotalElement.first().text();
+            subtotal = parsePrice(subtotalText);
             console.log('📊 Подытог без доставки:', subtotal, 'руб.');
         }
         

--- a/assets/js/cdek-delivery-classic.js
+++ b/assets/js/cdek-delivery-classic.js
@@ -1785,6 +1785,26 @@ jQuery(document).ready(function($) {
         hideCdekHint();
         // Обновляем отображение в чекауте
         updateClassicShippingCost({name: 'Самовывоз (г.Саратов, ул. Осипова, д. 18а)'}, 0);
+        
+        // Принудительно очищаем стоимость доставки СДЭК в сессии
+        if (typeof cdek_ajax !== 'undefined' && cdek_ajax.ajax_url) {
+            $.ajax({
+                url: cdek_ajax.ajax_url,
+                type: 'POST',
+                data: {
+                    action: 'update_cdek_shipping_cost',
+                    cdek_delivery_cost: 0,
+                    cdek_delivery_type: 'pickup',
+                    nonce: cdek_ajax.nonce
+                },
+                success: function(response) {
+                    console.log('✅ Стоимость доставки очищена для самовывоза');
+                },
+                error: function() {
+                    console.log('❌ Ошибка при очистке стоимости доставки');
+                }
+            });
+        }
     };
     
     window.updateShippingTextForManager = function() {
@@ -1793,6 +1813,26 @@ jQuery(document).ready(function($) {
         hideCdekHint();
         // Обновляем отображение в чекауте
         updateClassicShippingCost({name: 'Обсудить доставку с менеджером'}, 0);
+        
+        // Принудительно очищаем стоимость доставки СДЭК в сессии
+        if (typeof cdek_ajax !== 'undefined' && cdek_ajax.ajax_url) {
+            $.ajax({
+                url: cdek_ajax.ajax_url,
+                type: 'POST',
+                data: {
+                    action: 'update_cdek_shipping_cost',
+                    cdek_delivery_cost: 0,
+                    cdek_delivery_type: 'manager',
+                    nonce: cdek_ajax.nonce
+                },
+                success: function(response) {
+                    console.log('✅ Стоимость доставки очищена для менеджера');
+                },
+                error: function() {
+                    console.log('❌ Ошибка при очистке стоимости доставки');
+                }
+            });
+        }
     };
     
     // Инициализация при изменении метода доставки


### PR DESCRIPTION
Fixes SDEK delivery cost not clearing in backend/emails and resolves SDEK API calculation failures for large orders.

The SDEK delivery cost was not consistently cleared in the WooCommerce session when switching to 'Discuss with manager' or 'Pickup', leading to incorrect totals in order emails. This PR adds explicit AJAX calls to update the session. Additionally, the SDEK API was failing to calculate costs for very large orders (e.g., 1000 items) due to internal API limitations on the number of packages. The solution limits the maximum number of packages sent to the SDEK API to 5 and caps individual package weight at 30kg to ensure successful calculations. Improved price parsing in JS is also included as a general enhancement.

---
<a href="https://cursor.com/background-agent?bcId=bc-816d1438-d3ab-4886-b88a-22ac92c97bdb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-816d1438-d3ab-4886-b88a-22ac92c97bdb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>